### PR TITLE
slack 上でメッセージが全件表示されない不具合の修正

### DIFF
--- a/code.js
+++ b/code.js
@@ -137,7 +137,7 @@ function doGet (e) {
   const targetMonth = e.parameter.targetMonth
   Logger.log(isThisMonth)
   Logger.log(targetMonth)
-  return HtmlService.createHtmlOutput(getCalendarEvents2(calendarId, isThisMonth, targetMonth))
+  return HtmlService.createHtmlOutput(getCalendarEventsWithDeleteEventLinks(calendarId, isThisMonth, targetMonth))
 }
 
 // カレンダーに予定を追加する
@@ -197,7 +197,7 @@ function getList (events, calenderId, roomName, targetMonth, isThisMonth) {
 }
 
 // カレンダーから予定を取得する
-function getCalendarEvents2 (calendarId, isThisMonth, targetMonth) {
+function getCalendarEventsWithDeleteEventLinks (calendarId, isThisMonth, targetMonth) {
   const calendar = CalendarApp.getCalendarById(calendarId)
   if (isThisMonth === 'true') {
     const today = new Date() // 取得された日にち
@@ -205,19 +205,19 @@ function getCalendarEvents2 (calendarId, isThisMonth, targetMonth) {
     const endTime = new Date(today.getFullYear(), today.getMonth() + 1) // 取得された月の終わりの時間
     const events = calendar.getEvents(startTime, endTime)
 
-    return getList2(events, calendarId)
+    return getListWithDeleteEventLinks(events, calendarId)
   } else {
     const today = new Date(targetMonth + '-01 00:00:00')
     const startTime = new Date(today.getFullYear(), today.getMonth()) // 指定された月の初めの時間
     const endTime = new Date(today.getFullYear(), today.getMonth() + 1) // 指定された月の終わりの時間
     const events = calendar.getEvents(startTime, endTime)
 
-    return getList2(events, calendarId)
+    return getListWithDeleteEventLinks(events, calendarId)
   }
 }
 
 // listをメッセージにして返す
-function getList2 (events, calendarId) {
+function getListWithDeleteEventLinks (events, calendarId) {
   let i = 0
   const eventList = events.reduce((acc, cur) => {
     i++


### PR DESCRIPTION
### 内容
- slack 上で表示される予定の件数が増えると全件表示されない不具合の修正。
- 予定一つ一つに対応する `予定削除` リンクが文字数をかなり使用しているため、削除の機能はブラウザのページで行う。

### 改善点
- Slack にて表示される予定リストの先頭に `予定を削除する場合はこちら` のリンクを付け、そのリンク先にて削除の処理を行う。
- 削除のためのページではチェックボックスを選択して `削除` ボタンを押すと予定が削除される。

### 課題
- 削除後の完了メッセージが表示されない。